### PR TITLE
Remove 'self.inheritance_column = :type' statement

### DIFF
--- a/app/models/piece.rb
+++ b/app/models/piece.rb
@@ -15,8 +15,6 @@ class Piece < ActiveRecord::Base
       end
   end
 
-	self.inheritance_column = :type
-
   def self.types
     %w(Pawn Rook Knight Bishop Queen King)
   end


### PR DESCRIPTION
- Removed self.inheritance_column = :type from piece model (was redundant)