### PR TITLE
Lm-rook (new branch-cleanup for legal-move-rook)

### DIFF
--- a/app/models/piece.rb
+++ b/app/models/piece.rb
@@ -23,6 +23,18 @@ class Piece < ActiveRecord::Base
     raise NotImplementedError
 	end
 
+  def legal_horiz_move?(x, y)
+    (self.col_position - y) == 0
+  end
+
+  def legal_vert_move?(x, y)
+    (self.row_position - x) == 0
+  end  
+
+  def legal_diag_move?(x, y)
+    (self.row_position - x) == (self.col_position - y)
+  end
+
   def capturable?(x, y)
     Piece.where(:game_id => game.id, :row_position => x, :col_position => y, :alive => true).where.not(color: color).present?
   end

--- a/app/models/piece.rb
+++ b/app/models/piece.rb
@@ -28,6 +28,7 @@ class Piece < ActiveRecord::Base
   end
 
   def legal_vert_move?(x, y)
+    x >= 0 and x <= 7 and y >= 0 and y <= 7
     (self.row_position - x) == 0
   end  
 

--- a/app/models/piece.rb
+++ b/app/models/piece.rb
@@ -28,7 +28,6 @@ class Piece < ActiveRecord::Base
   end
 
   def legal_vert_move?(x, y)
-    x >= 0 and x <= 7 and y >= 0 and y <= 7
     (self.row_position - x) == 0
   end  
 

--- a/app/models/rook.rb
+++ b/app/models/rook.rb
@@ -7,11 +7,14 @@ class Rook < Piece
     puts "I'm a rook"
   end
 
-  	def legal_move?(x, y)
+  def legal_move?(x, y)
 		#rook's move is purely horizontal or vertical
-		(x >= 0 and x <= 7) and (y >= 0 and y <= 7)
-		self.legal_horiz_move?(x, y) || self.legal_vert_move?(x, y)
+		x >= 0 and x <= 7 and y >= 0 and y <= 7
+      if self.legal_horiz_move?(x, y) || self.legal_vert_move?(x, y)
 		 		#add conditions for kingside and queenside castling (i.e. rook moves horizontally (or vertically?) around king or queen)
-	end
+      else
+        false	   
+      end
+  end
   
 end

--- a/app/models/rook.rb
+++ b/app/models/rook.rb
@@ -9,7 +9,7 @@ class Rook < Piece
 
   def legal_move?(x, y)
 		#rook's move is purely horizontal or vertical
-		x >= 0 and x <= 7 and y >= 0 and y <= 7
+		x > 0 and y > 0
     if self.legal_horiz_move?(x, y) || self.legal_vert_move?(x, y)
 		 		#add conditions for kingside and queenside castling (i.e. rook moves horizontally (or vertically?) around king or queen) 
       return true

--- a/app/models/rook.rb
+++ b/app/models/rook.rb
@@ -9,7 +9,8 @@ class Rook < Piece
 
   	def legal_move?(x, y)
 		#rook's move is purely horizontal or vertical
-		self.horiz_move? || self.vert_move?
+		(x >= 0 and x <= 7) and (y >= 0 and y <= 7)
+		self.legal_horiz_move?(x, y) || self.legal_vert_move?(x, y)
 		 		#add conditions for kingside and queenside castling (i.e. rook moves horizontally (or vertically?) around king or queen)
 	end
   

--- a/app/models/rook.rb
+++ b/app/models/rook.rb
@@ -10,11 +10,11 @@ class Rook < Piece
   def legal_move?(x, y)
 		#rook's move is purely horizontal or vertical
 		x >= 0 and x <= 7 and y >= 0 and y <= 7
-      if self.legal_horiz_move?(x, y) || self.legal_vert_move?(x, y)
-		 		#add conditions for kingside and queenside castling (i.e. rook moves horizontally (or vertically?) around king or queen)
-      else
-        false	   
-      end
+    if self.legal_horiz_move?(x, y) || self.legal_vert_move?(x, y)
+		 		#add conditions for kingside and queenside castling (i.e. rook moves horizontally (or vertically?) around king or queen) 
+      return true
+    else
+      return false	   
+    end
   end
-  
 end

--- a/app/models/rook.rb
+++ b/app/models/rook.rb
@@ -9,12 +9,8 @@ class Rook < Piece
 
   	def legal_move?(x, y)
 		#rook's move is purely horizontal or vertical
-		if (self.row_position - x) == 0 or (self.col_position - y) == 0 
+		self.horiz_move? || self.vert_move?
 		 		#add conditions for kingside and queenside castling (i.e. rook moves horizontally (or vertically?) around king or queen)
-			return true
-		else
-			return false
-		end
 	end
   
 end

--- a/test/models/rook_test.rb
+++ b/test/models/rook_test.rb
@@ -2,7 +2,7 @@
 
 # class RookTest < ActiveSupport::TestCase
 
-<<<<<<< HEAD
+
   test "rook legal_move off board returns false" do
   	rook = FactoryGirl.create(:rook, :row_position => 0, :col_position => 0)
     refute rook.legal_move?(0, -1)
@@ -29,11 +29,3 @@
   #add tests for castling once castling logic is done
 
 end
-=======
-#   test "rook legal_move" do
-
-#     rook = FactoryGirl.create(:rook, :type => 'Rook', :color => 'White', :row_position => 0, :col_position => 0)
-#     assert_equal true, rook.legal_move?(0, 2)
-#   end
-# end
->>>>>>> master

--- a/test/models/rook_test.rb
+++ b/test/models/rook_test.rb
@@ -2,9 +2,21 @@ require 'test_helper'
 
 class RookTest < ActiveSupport::TestCase
 
-  test "rook legal_move" do
-
-    rook = FactoryGirl.create(:rook, :type => 'Rook', :color => 'White', :row_position => 0, :col_position => 0)
-    assert_equal true, rook.legal_move?(0, 2)
+  test "rook legal_move off board returns false" do
+  	rook = FactoryGirl.create(:rook, :row_position => 0, :col_position => 0)
+    refute rook.legal_move?(0, -1)
+    refute rook.legal_move?(-1, 0)
+    refute rook.legal_move?(0, 8)
+    refute rook.legal_move?(8, 0)
   end
+
+  test "rook legal_move one move in two directions returns false" do
+  	rook = FactoryGirl.create(:rook, :row_position => 0, :col_position => 0)
+    refute rook.legal_move?(3, 1)
+    refute rook.legal_move?(5, 5)
+    refute rook.legal_move?(1, 1)
+  end
+
+  #add tests for castling once castling logic is done
+
 end

--- a/test/models/rook_test.rb
+++ b/test/models/rook_test.rb
@@ -17,6 +17,14 @@ class RookTest < ActiveSupport::TestCase
     refute rook.legal_move?(1, 1)
   end
 
+  test "rook legal_move one move in one direction returns true" do
+    rook = FactoryGirl.create(:rook, :row_position => 0, :col_position => 0)
+    assert rook.legal_move?(0, 2)
+    assert rook.legal_move?(1, 0)
+    assert rook.legal_move?(0, 6)
+    assert rook.legal_move?(6, 0)
+  end
+
   #add tests for castling once castling logic is done
 
 end


### PR DESCRIPTION
Left an explicit 'return false' statement in rook logic b/c tests wouldn't pass without it, possibly b/c of "||" operator somehow returning 'nil' even though at least one of x and y meet the out-of-bounds conditions. Also, I left the conditions in until the rook logic and tests are merged then I will put them back in the piece model in the attempt_move method.