### PR TITLE
Lm knight (branch cleanup for legal-move)

### DIFF
--- a/app/models/knight.rb
+++ b/app/models/knight.rb
@@ -1,11 +1,13 @@
 class Knight < Piece
   def legal_move?(x, y)
     # knight moves two squares in horiz. or vertical then one space in the other of the two directions 
-    if ((self.row_position - x).abs == 2 and (self.col_position - y).abs == 1) or ((self.col_position - y).abs == 2 and (self.row_position - x).abs == 1)
-      return true		
+    if x >= 0 and x <= 7 and y >= 0 and y <= 7
+      if ((self.row_position - x).abs == 2 and (self.col_position - y).abs == 1) or ((self.col_position - y).abs == 2 and (self.row_position - x).abs == 1)
+        return true   
+      end
     else
       return false
-    end	
+    end 
   end
 
   def obstructed_positions(x, y)

--- a/app/models/piece.rb
+++ b/app/models/piece.rb
@@ -23,6 +23,18 @@ class Piece < ActiveRecord::Base
     raise NotImplementedError
 	end
 
+  def legal_horiz_move?(x, y)
+    (self.col_position - y) == 0
+  end
+
+  def legal_vert_move?(x, y)
+    (self.row_position - x) == 0
+  end  
+
+  def legal_diag_move?(x, y)
+    (self.row_position - x).abs == (self.col_position - y).abs
+  end
+
   def capturable?(x, y)
     Piece.where(:game_id => game.id, :row_position => x, :col_position => y, :alive => true).where.not(color: color).present?
   end

--- a/test/models/knight_test.rb
+++ b/test/models/knight_test.rb
@@ -4,6 +4,6 @@ class KnightTest < ActiveSupport::TestCase
  test "white knight_legal_move" do
 
    knight = FactoryGirl.create(:knight, :type => 'Knight', :row_position => 1, :col_position => 0)
-   assert_equal true, knight.legal_move?(2, 2) 
+   assert knight.legal_move?(2, 2) 
   end
 end

--- a/test/models/knight_test.rb
+++ b/test/models/knight_test.rb
@@ -1,9 +1,29 @@
 require 'test_helper'
 
 class KnightTest < ActiveSupport::TestCase 
- test "white knight_legal_move" do
-
-   knight = FactoryGirl.create(:knight, :type => 'Knight', :row_position => 1, :col_position => 0)
+ test "knight_legal_move left-right then up-down return true" do
+   knight = FactoryGirl.create(:knight, :row_position => 4, :col_position => 3)
+   assert knight.legal_move?(6, 4)
+   assert knight.legal_move?(6, 2)
+   assert knight.legal_move?(2, 4)
    assert knight.legal_move?(2, 2) 
+  end
+
+  test "knight_legal_move up-down then left-right return true" do
+
+   knight = FactoryGirl.create(:knight, :row_position => 4, :col_position => 3)
+   assert knight.legal_move?(5, 5)
+   assert knight.legal_move?(5, 1)
+   assert knight.legal_move?(3, 5) 
+   assert knight.legal_move?(3, 1)
+  end
+
+  test "knight_legal_move off board return false" do
+   knight = FactoryGirl.create(:knight, :row_position => 1, :col_position => 0)
+   refute knight.legal_move?(-1, 1)
+   refute knight.legal_move?(-1, -1)
+   refute knight.legal_move?(3, -1)
+   refute knight.legal_move?(0, -2)
+   refute knight.legal_move?(2, -2) 
   end
 end


### PR DESCRIPTION
I left the knight logic as is, no use of legal_horiz, legal_vert or legal_diag_move methods in piece.rb. As with the other pieces' logic, I added the out-of-bound conditions for the tests to pass. All tests pass.